### PR TITLE
compiler: resolve panic in substituteTypeArgs Function for `*ast.IndexListExpr`

### DIFF
--- a/compiler/types.go
+++ b/compiler/types.go
@@ -197,6 +197,15 @@ func substituteTypeArgs(p *packages.Package, expr ast.Expr, typeArg func(*types.
 			X:     substituteTypeArgs(p, e.X, typeArg),
 			Index: substituteTypeArgs(p, e.Index, typeArg),
 		}
+	case *ast.IndexListExpr:
+		indices := make([]ast.Expr, len(e.Indices))
+		for i, index := range e.Indices {
+			indices[i] = substituteTypeArgs(p, index, typeArg)
+		}
+		return &ast.IndexListExpr{
+			X:       substituteTypeArgs(p, e.X, typeArg),
+			Indices: indices,
+		}
 	case *ast.Ident:
 		t := p.TypesInfo.TypeOf(e)
 		tp, ok := t.(*types.TypeParam)


### PR DESCRIPTION
Fixes: #141

This PR addresses a panic occurring in the `substituteTypeArgs` function within the `types.go` file. The panic is caused by the lack of handling for the `*ast.IndexListExpr` type, resulting in unexpected behavior during type substitution.
