### PR TITLE
Quick fix for the blog url

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 This project contains a durable coroutine compiler and runtime library for Go.
 
 > **Note**
-> Read our announcement blog post: [Fairy tales of workflow orchestration](https://blog.dispatch.run/fairy-tales-of-workflow-orchestration/).
+> Read our announcement blog post: [Fairy tales of workflow orchestration](https://dispatch.run/blog/fairy-tales-of-workflow-orchestration/).
 
 ## Usage
 


### PR DESCRIPTION
The blog link has blog as the subdomain and instead it should be a part of the subdirectory in the link. This PR moves it to the correct location. Side note, the about section of the repo still has `stealthrocket.tech`.